### PR TITLE
docs: enforce conventional commit format for PR titles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ docs/                    # Design documents (not part of plugin)
 
 ## Conventions
 
+- **Conventional Commits** for all commit messages and PR titles: `<type>(<scope>): <description>` (types: `feat`, `fix`, `refactor`, `docs`, `chore`, `test`, `style`, `perf`)
 - Agent markdown files go in `plugins/nightshift/agents/` (source of truth)
 - When installed in a target repo, agents go in `.github/nightshift/agents/`
 - Workflow templates go in `plugins/nightshift/workflows/`

--- a/plugins/nightshift/skills/creating-pull-requests/SKILL.md
+++ b/plugins/nightshift/skills/creating-pull-requests/SKILL.md
@@ -68,8 +68,30 @@ Group changes by **logical concern** (not by file):
 
 ### 5. Create the PR
 
+**Title must follow [Conventional Commits](https://www.conventionalcommits.org/):**
+
+`<type>(<optional scope>): <short description>`
+
+| Type | When |
+|------|------|
+| `feat` | New feature or capability |
+| `fix` | Bug fix |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `docs` | Documentation only |
+| `chore` | Build, CI, tooling, dependencies |
+| `test` | Adding or fixing tests |
+| `style` | Formatting, whitespace (no logic change) |
+| `perf` | Performance improvement |
+
+Examples:
+- `feat: add JWT-based authentication`
+- `fix(auth): handle expired refresh tokens`
+- `chore: upgrade dependencies to latest`
+
+**Why this matters:** GitHub uses the PR title as the squash-merge commit message. A conventional commit title means the merge commit is correctly formatted without manual editing.
+
 ```bash
-gh pr create --title "<concise title, under 70 chars>" --body "$(cat <<'EOF'
+gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
 <the description from step 4>
 EOF
 )"
@@ -83,6 +105,7 @@ Add flags as appropriate:
 
 ## Quality Bar
 
+- **Conventional commit title:** Must start with `type:` or `type(scope):` — no exceptions
 - **Self-contained:** A reader should understand the PR without clicking through to issues
 - **Intent over mechanics:** "Add user authentication" not "modify 5 files"
 - **Embedding-friendly:** Include technology names, pattern names, and domain terms naturally


### PR DESCRIPTION
## Summary

GitHub's squash-merge uses the PR title as the commit message first line. By enforcing Conventional Commit format (`type(scope): description`) on PR titles, the merged commit is automatically formatted correctly without manual editing.

## Changes

- Added comprehensive conventional commit type reference table to the PR skill
- Explained why this matters for GitHub's squash-merge workflow
- Made conventional commit format a hard requirement in the quality bar
- Updated project CLAUDE.md to document conventional commits as a standard

## Test Plan

- [ ] Create a PR with title like `feat(auth): add JWT support` and verify it becomes the commit message on squash-merge
- [ ] Verify the skill guide is clear on acceptable commit types