### PR TITLE
refactor: move setup commands from skills/ to commands/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,10 @@ plugins/nightshift/      # The nightshift plugin
   .claude-plugin/        # Plugin manifest
   agents/                # Agent prompt library (source markdown files)
   workflows/             # GitHub Actions workflow templates
-  skills/                # Claude Code plugin skills
-    nightshift/          # /nightshift interactive setup skill
+  commands/              # User-invoked slash commands
+    setup-project.md     # /nightshift:setup-project
+    setup-agents.md      # /nightshift:setup-agents
+  skills/                # Model-invoked agent skills (auto-triggered by context)
     creating-issues/
     creating-pull-requests/
     writing-wiki-pages/
@@ -27,7 +29,7 @@ docs/                    # Design documents (not part of plugin)
 
 - **Agents** are markdown files that define what Claude should do (review code, audit security, etc.)
 - **Workflows** are GitHub Actions YAML files that define when agents run (cron, PR, label, manual)
-- **The `/nightshift` skill** scaffolds agents + workflows into a target repo interactively
+- **`/nightshift:setup-project`** and **`/nightshift:setup-agents`** are user-invoked slash commands for repo setup
 - Agent prompts point Claude to the `.md` file in the target repo: `Read and follow the agent instructions in .github/nightshift/agents/<name>.md`
 
 ## Conventions
@@ -38,7 +40,8 @@ docs/                    # Design documents (not part of plugin)
 - Workflow templates go in `plugins/nightshift/workflows/`
 - When installed, workflows go in `.github/workflows/nightshift-*.yml`
 - All workflows include `workflow_dispatch` for manual triggering
-- Skills follow the `SKILL.md` convention in `plugins/nightshift/skills/<name>/SKILL.md`
+- Slash commands go in `plugins/nightshift/commands/<name>.md` (user-invoked)
+- Agent skills follow the `SKILL.md` convention in `plugins/nightshift/skills/<name>/SKILL.md` (model-invoked)
 
 ## GitHub Project Board
 

--- a/README.md
+++ b/README.md
@@ -85,20 +85,27 @@ Agents run automatically on their configured triggers. Customize any agent by ed
 
 **Add/remove agents:** Just ask Claude in your repo: "Add the dead code detector, run it monthly" or "Remove the security auditor". Or run `/nightshift:setup-agents` again.
 
-## Plugin Skills
+## Slash Commands
 
-When installed, Nightshift also provides these Claude Code skills for your workflow:
+User-invoked commands for setup and configuration:
 
-| Skill | Purpose |
-|-------|---------|
+| Command | Purpose |
+|---------|---------|
 | `/nightshift:setup-project` | Repo infrastructure setup (project board, wiki, labels, branch protection) |
-| `/nightshift:setup-agents` | Interactive agent setup |
-| Creating issues | Structured GitHub issue creation |
-| Creating pull requests | Well-formatted PR descriptions |
-| Writing wiki pages | GitHub Wiki documentation |
-| Writing project updates | GitHub Projects updates |
-| Writing ADRs | Architecture Decision Records |
-| Updating READMEs | README maintenance |
+| `/nightshift:setup-agents` | Interactive agent setup and scaffolding |
+
+## Agent Skills
+
+When installed, Nightshift also provides Claude Code skills that Claude uses automatically based on context:
+
+| Skill | When it activates |
+|-------|-------------------|
+| Creating issues | When creating, updating, or commenting on GitHub issues |
+| Creating pull requests | When creating a pull request or submitting work for review |
+| Writing wiki pages | When documenting architecture, onboarding guides, or runbooks |
+| Writing project updates | After completing meaningful work (features merged, decisions made) |
+| Writing ADRs | When making architectural decisions or choosing between approaches |
+| Updating READMEs | When project structure, setup instructions, or capabilities change |
 
 ## How It Works
 

--- a/plugins/nightshift/commands/setup-agents.md
+++ b/plugins/nightshift/commands/setup-agents.md
@@ -1,5 +1,4 @@
 ---
-name: setup-agents
 description: Set up Nightshift agents in a repository — scaffolds agent prompts and GitHub Actions workflows for automated code review, security audits, dependency updates, and more
 ---
 

--- a/plugins/nightshift/commands/setup-project.md
+++ b/plugins/nightshift/commands/setup-project.md
@@ -1,5 +1,4 @@
 ---
-name: setup-project
 description: Set up GitHub Project board, wiki, labels, and branch protection for a repository — one-time repo infrastructure scaffolding
 ---
 


### PR DESCRIPTION
## Summary

Moves `setup-project` and `setup-agents` from `skills/` to `commands/` so they register as user-invoked slash commands instead of model-invoked agent skills. Previously, `/setup-agents` and `/nightshift` failed with "Unknown skill" errors because the plugin spec treats `skills/` as model-invoked and `commands/` as user-invoked.

## Changes

- **Moved `setup-project` and `setup-agents`** from `plugins/nightshift/skills/` to `plugins/nightshift/commands/` — these are explicit user actions, not contextual auto-triggers
- **Split README "Plugin Skills" section** into "Slash Commands" (user-invoked: setup-project, setup-agents) and "Agent Skills" (model-invoked: creating-issues, creating-pull-requests, etc.)
- **Updated CLAUDE.md** repo structure and conventions to document both `commands/` and `skills/` directories

## Context

Per the [Claude Code plugin docs](https://code.claude.com/docs/en/plugins), `commands/` holds user-invoked slash commands while `skills/` holds model-invoked agent skills. The setup flows are always user-initiated, so they belong in `commands/`.

## Test Plan

- [ ] Install plugin and verify `/nightshift:setup-project` and `/nightshift:setup-agents` work as slash commands
- [ ] Verify model-invoked skills (creating-issues, creating-pull-requests, etc.) still auto-activate in context
- [ ] Run `/help` and confirm setup commands appear in the plugin namespace